### PR TITLE
fixed minor bugs and changed menu navigation

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -84,14 +84,14 @@ html, body {
   --sidebar-ring: oklch(0.708 0 0);
 }
 
-a {
+/* a {
   font-weight: 500;
   color: #646cff;
   text-decoration: inherit;
 }
 a:hover {
   color: #535bf2;
-}
+} */
 
 
 html, body, #root {
@@ -136,9 +136,9 @@ button:focus-visible {
     color: #213547;
     background-color: #ffffff;
   }
-  a:hover {
+  /* a:hover {
     color: #747bff;
-  }
+  } */
   button {
     background-color: #f9f9f9;
   }

--- a/frontend/src/pages/client/ClientLayout.jsx
+++ b/frontend/src/pages/client/ClientLayout.jsx
@@ -9,7 +9,7 @@ const navLinks = [
     { to: "/", label: "Hjem" },
     { to: "/about", label: "Om Oss" },
     { to: "/sales-process", label: "Salgs- og kjøpsprosessen" },
-    { to: "https://www.finn.no/mobility/search/car/mobilehome?orgId=9411670", label: "Til Salgs" },
+    { to: "/for-sale", label: "Til Salgs" },
     { to: "/contact", label: "Kontakt Oss" },
     { to: "/complaints", label: "Reklamasjon" },
 ];

--- a/frontend/src/pages/client/ForSalePage.jsx
+++ b/frontend/src/pages/client/ForSalePage.jsx
@@ -12,9 +12,10 @@ const ForSalePage = () => {
                 <div className="flex flex-col sm:flex-row gap-4">
                     <a
                         href="https://www.finn.no/mobility/search/car/mobilehome?orgId=8250738"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-block rounded-full bg-[#047464] text-white px-8 py-3 text-lg font-medium shadow-md hover:bg-[#03594d] transition-all duration-300">
+                        // target="_blank"
+                        // rel="noopener noreferrer"
+                        className="inline-block rounded-full bg-primary text-white px-8 py-3 text-lg font-medium shadow-md hover:bg-primary-dark transition-all duration-300"
+                        >
                         Se biler på Finn.no
                     </a>
                 </div>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -7,7 +7,7 @@ export default {
   theme: {
     extend: {
       colors: { // Egendefinerte farger
-        primary: "#FF914D",
+        "primary": "#FF914D",
         "primary-light": "#FFE4D1",
         "primary-dark": "#E6732B",
         // "ui-background": "#34495e",


### PR DESCRIPTION
argumenter for hvorfor det er bedre slik, selv om kunden ikke i utgangspunktet ønsket det: 
* Bedre SEO: En egen /for-sale-side gir Google en faktisk side å indeksere, i stedet for at trafikken sendes rett ut til Finn.
* Støtter kundens SEO-mål: Kunden har bedt om SEO, og da bør viktige menypunkter lede til innhold på eget domene.
* Mer profesjonell navigasjon: Hovedmenyen bør primært navigere internt på nettstedet, ikke kaste brukeren direkte ut til en ekstern tjeneste.
* Bedre brukerforståelse: Brukeren får kontekst først: “Vi legger ut bilene våre på Finn”, før de velger å gå videre.
* Mer helhetlig nettside: Siden oppleves mer komplett når “Til salgs” faktisk har en egen landingsside.
* Fremtidssikkert: Senere kan siden utvides med utvalgte biler, FAQ, kjøpsprosess, kontaktinfo eller integrasjon mot annonser.
* Bedre kontroll: Dere eier innholdet på egen side, mens Finn-profilen er en ekstern plattform dere ikke kontrollerer.
* Mindre brå overgang: Brukeren forstår tydeligere at de sendes videre til Finn når det skjer fra en knapp på siden, ikke direkte fra menyen.
* Bedre konvertering: En intern side kan varme opp brukeren før klikket til Finn, f.eks. med tillitsskapende tekst og kontaktmuligheter.
* Faglig anbefaling: Kunden kan fortsatt få en knapp som åpner Finn i samme fane, men det bør skje fra en intern side — ikke direkte fra hovedmenyen.